### PR TITLE
fix: sync main with current local add-on contract

### DIFF
--- a/.config/opencode.json
+++ b/.config/opencode.json
@@ -15,7 +15,7 @@
     "zotero_collections": "allow",
     "zotero_children": "allow",
     "zotero_batch_add": "allow",
-    "zotero_delete_items": "allow",
+    "zotero_trash_items": "allow",
     "zotero_check_pdfs": "allow",
     "zotero_crossref": "allow",
     "zotero_find_dois": "allow",

--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,6 @@
+.serena/
+node_modules/
+__pycache__/
+*.py[cod]
+.pytest_cache/
+

--- a/CONTINUATION.md
+++ b/CONTINUATION.md
@@ -1,160 +1,57 @@
 # Continuation: opencode-zotero-plugin
 
-## Current state
+## Source of truth
 
-- Python package split: done. 16 modules in `python/src/zotero_librarian/`.
-- `__init__.py`: minimal — only `get_zotero` + `__version__`. No re-exports.
-- `_dispatch.py`: imports from specific submodules directly.
-- Tests: all import from submodules. Offline tests pass (10/10).
-- TS plugin `src/index.ts`: 9 composite tools shelling to `_dispatch.py`.
-- MCP server `mcp-server/server.py`: 9 FastMCP tools via direct Python imports.
-- `zotero/agents.py`: deleted.
-- `zotero/_dev/scripts/manage.py`: deleted.
-- `zotero/justfile`: rewired to `zotero-lib` CLI.
+- Use `REQUIREMENTS.md` as the canonical continuation and release-gating document.
+- Do not revive the old Zotero Web API / `remote.py` migration plan. The current product direction is local-only.
+- Reads come from the local Zotero API. Writes go through `/connector/...` plus the add-on endpoints configured in `python/src/zotero_librarian/config.yaml` and discovered from the add-on version probe.
 
----
+## Current implementation status
 
-## 1. CRITICAL: Integrate `scripts/zotero.py` into the plugin
+- PR #22 merged into `main` on 2026-03-10 and implemented issues #9, #10, #12-#16, #18, and #20.
+- PR #23 merged into `main` on 2026-03-10 and implemented issue #11 (Better BibTeX lookup) and issue #17 (Markdown PDF extraction with `docling` default and optional `mineru`).
+- Open GitHub issues: none.
+- Main surfaces:
+  - TypeScript plugin: `src/index.ts`
+  - Python dispatcher: `python/src/zotero_librarian/_dispatch.py`
+  - Human CLI: `python/src/zotero_librarian/_cli.py`
+  - MCP server: `mcp-server/server.py`
+- Extraction direction:
+  - single public entrypoint: `extract_and_attach_text(...)`
+  - Markdown attachment output only
+  - `docling` by default
+  - optional `mineru` selected via `ZOTERO_PDF_EXTRACTOR` and `ZOTERO_MINERU_CMD`
 
-**This is the main unfinished task.** The remote Web API script at
-`zotero/scripts/zotero.py` must become a proper module in the plugin,
-not a separate standalone script.
+## Fresh verification snapshot
 
-### What it provides (not covered by local API modules)
+- `bun install`
+- `bun run typecheck`
+- `cd python && uv run python -c 'import zotero_librarian; print("Python import OK")'`
+- `cd python && uv run pytest tests/test_validation.py tests/test_dispatch.py -v`
+- `cd mcp-server && uv run python -c 'import server; print("ok")'`
 
-- `add-doi` / `add-isbn` / `add-pmid` — lookup via Zotero translation server
-  (distinct from the local-API `import_by_doi` which uses a different mechanism)
-- `find-dois` — CrossRef lookup to fill in missing DOIs
-- `fetch-pdfs` — Unpaywall/open-access PDF fetching
-- `crossref` — cross-reference a text file of citations against the library
-- `batch-add` — add multiple items from a file of DOIs/ISBNs
-- `export` — BibTeX/RIS/CSL-JSON export via remote API
+Live Zotero-dependent proof has not been rerun in this handoff.
 
-### Target module
+## Current repo state
 
-Create `python/src/zotero_librarian/remote.py`:
-- Move all logic from `scripts/zotero.py` into proper functions
-- Config via `get_web_config()` reading `ZOTERO_API_KEY` + `ZOTERO_USER_ID` / `ZOTERO_GROUP_ID`
-- Keep zero-stdlib-dependency constraint (or add `httpx` — already a dep)
-- Functions: `web_items()`, `web_search()`, `web_get()`, `web_collections()`,
-  `web_tags()`, `web_add_doi()`, `web_add_isbn()`, `web_add_pmid()`,
-  `web_batch_add()`, `web_find_dois()`, `web_fetch_pdfs()`, `web_crossref()`,
-  `web_export()`, `web_update()`, `web_delete()`
+- The local checkout is still on `pr-impl`, but `origin/main` already contains the merged work.
+- Start new feature work from updated `main` or a fresh branch from it.
+- Review existing tracked local changes before rebasing or committing. At the time of this handoff, `justfile` and `mcp-server/uv.lock` already differed from HEAD.
+- Generated local artifacts such as `node_modules/`, `.serena/`, and `__pycache__/` are not source.
 
-### Wire it into everything
+## Next meaningful work
 
-1. **`pyproject.toml`**: no new deps needed (uses `httpx` already in deps)
-2. **`_dispatch.py`**: add remote tool entries (keyed `remote_*`)
-3. **`_cli.py`**: add `remote` subcommand group (or integrate into existing commands)
-4. **`mcp-server/server.py`**: add `zotero_remote_*` tools
-5. **`src/index.ts`**: add TS tool wrappers for remote operations
-6. **`tests/test_remote.py`**: tests against live remote API (skip if no API key)
-7. **Delete `zotero/scripts/zotero.py`** once migrated
+- Run the live proof gates from `REQUIREMENTS.md` with Zotero 7 running and the local add-on endpoints available:
+  - `cd python && uv run pytest tests/ -v`
+  - `cd python && uv run python -m zotero_librarian._dispatch count_items '{}'`
+  - `cd python && uv run zotero-lib stats summary`
+  - `\opencode run --agent Minimal 'How many items in my Zotero library?'`
+- Verify explicit structured failure paths for local write operations, not just successful writes.
+- Prove trash semantics locally if the bridge is available. This remains non-gating but still open in `REQUIREMENTS.md`.
+- Keep sync conflict resolution out of release gating unless `REQUIREMENTS.md` is updated to promote it.
 
----
+## Known pitfalls
 
-## 2. Live Zotero tests
-
-Zotero was not running during the last session. Once started:
-
-```bash
-# Full test suite
-cd ./opencode-zotero-plugin/python
-uv run pytest tests/ -v
-
-# Specific verification commands from the plan
-uv run python -m zotero_librarian._dispatch count_items '{}'
-uv run zotero-lib stats summary
-```
-
-Expected: 146 currently-skipped tests become active.
-
-Failures to look for:
-- `_cli.py`: `find-similar-tags` command uses an inline python invocation instead
-  of calling `similar_tags()` from `duplicates.py` — should be a proper subcommand.
-- `_cli.py` `collections` subcommand uses `--item-key` / `--collection-key` flags
-  that argparse needs to supply as `args.item_key` / `args.collection_key` — verify
-  argparse uses underscores not hyphens for dest names.
-
----
-
-## 3. TS plugin: live test
-
-```bash
-cd ./opencode-zotero-plugin
-bun install   # already done
-\opencode run --agent Minimal "How many items in my Zotero library?"
-```
-
-This exercises the full TS → `_dispatch.py` → local API path.
-
----
-
-## 4. MCP server: install and smoke test
-
-```bash
-cd ./opencode-zotero-plugin/mcp-server
-uv sync
-uv run fastmcp run server.py
-```
-
-The `pyproject.toml` references `zotero-librarian` as an editable path dep
-(`{ path = "../python", editable = true }`). Verify `uv sync` resolves it.
-
----
-
-## 5. `_cli.py` bugs to fix before live testing
-
-- `find-similar-tags` just recipe in `justfile` uses inline python. The `_cli.py`
-  `search` subcommand doesn't have a `similar-tags` action. Add it.
-- `tags` subcommand's `--item-key` / `--item_key` argparse dest: verify
-  `args.item_key` not `args.item-key` (argparse converts hyphens to underscores
-  for dest, so `--item-key` → `args.item_key` — should be fine, but confirm).
-- `import` is a Python keyword — the subparser name `"import"` is fine as a
-  string but confirm `args.command == "import"` works correctly in the handler
-  dispatch dict (it does, but test it).
-
----
-
-## 6. Update `zotero/SKILL.md`
-
-Still references `scripts/zotero.py` as the tool interface. Once `remote.py` is
-integrated and `scripts/zotero.py` is deleted, update SKILL.md to point to
-`zotero-lib` (CLI) and the new plugin tools.
-
----
-
-## 7. `zotero/AGENTS.md` cleanup
-
-The bulk of `AGENTS.md` is still the old per-function table for `agents.py`.
-After live testing confirms the new plugin works, replace the whole file with a
-pointer to `../opencode-zotero-plugin/AGENTS.md`.
-
----
-
-## 8. Register MCP server in system opencode config
-
-Once verified, add to `./ai/` opencode config:
-```json
-{
-  "mcp": {
-    "zotero": {
-      "type": "stdio",
-      "command": "uv",
-      "args": ["run", "--directory", "./opencode-zotero-plugin/mcp-server", "fastmcp", "run", "server.py"]
-    }
-  }
-}
-```
-
----
-
-## Order of operations
-
-1. Integrate `remote.py` from `scripts/zotero.py` (Item 1 above — main task)
-2. Start Zotero, run `uv run pytest tests/ -v` (Item 2)
-3. Fix any `_cli.py` issues found (Item 5)
-4. Run TS plugin live test (Item 3)
-5. Run MCP server live test (Item 4)
-6. Delete `zotero/scripts/zotero.py`, update `SKILL.md` and `AGENTS.md` (Items 6-7)
-7. Register MCP in system config (Item 8)
+- The previous version of this file pointed to a forbidden Web API continuation path. Ignore that plan.
+- Run `bun install` before `bun run typecheck`. Without a local install, the command may fall back to an older global `tsc`.
+- Do not reopen issue #21 as a ChromaDB/vector-store task. Current direction is keyword search over extracted Markdown plus local semantic search over `.md` files.

--- a/REQUIREMENTS.md
+++ b/REQUIREMENTS.md
@@ -15,8 +15,13 @@ Tests, live proofs, and other gates apply after the required implementation chec
 1. Use the local Zotero surfaces only.
    Reads come from `http://127.0.0.1:23119/api/...`.
    Writes come from local desktop surfaces such as `http://127.0.0.1:23119/connector/...`
-   and installed local plugin endpoints such as `http://127.0.0.1:23119/fulltext-attach`
-   and `http://127.0.0.1:23119/opencode-zotero-write`.
+   and the installed local add-on endpoints described in
+   `python/src/zotero_librarian/config.yaml` and reported by the add-on version probe.
+1. The local add-on is part of the owned stack.
+   If a release-gating bug is in the add-on, fix the add-on at the source and
+   update the client contract or version gate as needed.
+   Do not treat owned add-on bugs as external blockers and do not paper them
+   over here as the final state.
 1. External enrichment remains allowed.
    Crossref, PubMed, Unpaywall, Semantic Scholar, arXiv, and similar metadata/PDF sources are in scope.
 1. Agents must be able to write locally.
@@ -27,9 +32,9 @@ Tests, live proofs, and other gates apply after the required implementation chec
    attach PDFs and other files;
    attach markdown or note text;
    place or finalize items into collections.
-1. Deletion is not a release requirement.
-   Permanent delete is forbidden.
-   If a delete surface exists, it must mean move to trash only, and it must not claim success until the local trash path is proven.
+1. Trash is the only supported removal surface.
+   Permanent deletion is forbidden in this repo and the local add-on.
+   Any removal surface must mean move to trash only, and it must not claim success until the local trash path is proven.
 1. Silent fallbacks are forbidden.
    No broad `except Exception: pass`, no `return None` on user-facing failures, no hidden retries that erase the real failing stage.
 1. Mutating operations must return structured results end to end.
@@ -39,6 +44,11 @@ Tests, live proofs, and other gates apply after the required implementation chec
    A local write failure may not be flattened into a generic command failure.
 1. Proof must use real Zotero and real external services.
    Mocks do not satisfy completion for this refactor.
+1. Adversarial testing targets the caller, not Zotero's database.
+   Use adversarial tests to prove agent/tool-contract behavior, unsafe sequencing,
+   and failure propagation against a real Zotero.
+   Do not spend release effort re-testing Zotero's own field validation or
+   pathological stored metadata values.
 
 ## Implementation Checklist
 
@@ -51,9 +61,9 @@ Tests, live proofs, and other gates apply after the required implementation chec
 - [x] Batch/enrichment accounting no longer counts failed attachment or update attempts as success.
 - [x] Existing-item metadata edits are implemented through a local write surface.
 - [x] Existing-item tag edits are implemented through a local write surface.
-  Add, remove, rename, merge, and delete-on-item semantics.
+  Add, remove, rename, merge, and remove-tag semantics.
 - [x] Existing-item collection placement/finalization is implemented through a local write surface.
-- [x] Existing-item PDF and file attachment writes are implemented through the installed `/fulltext-attach` plugin endpoint.
+- [x] Existing-item PDF and file attachment writes are implemented through the installed add-on's configured attach endpoint.
 - [x] Existing-item link attachment writes are implemented through a local write surface.
 - [x] Existing-item markdown/note attachment writes are implemented through a local write surface.
 - [x] Existing note edits are implemented through a local write surface.

--- a/mcp-server/server.py
+++ b/mcp-server/server.py
@@ -10,8 +10,8 @@ from pydantic import Field
 sys.path.insert(0, str(Path(__file__).parent.parent / "python" / "src"))
 
 from zotero_librarian.attachments import extract_and_attach_text, rename_pdf_attachments
-from zotero_librarian.batch import batch_delete_items
-from zotero_librarian.cleanup import clean_missing_pdfs, delete_all_notes, delete_snapshots
+from zotero_librarian.batch import batch_trash_items
+from zotero_librarian.cleanup import clean_missing_pdfs, trash_all_notes, trash_snapshots
 from zotero_librarian.client import count_items, get_zotero
 from zotero_librarian.duplicates import duplicate_dois, duplicate_titles, find_fuzzy_duplicates_by_title
 from zotero_librarian.enrichment import (
@@ -24,7 +24,7 @@ from zotero_librarian.enrichment import (
 )
 from zotero_librarian.export import export_collection, export_to_bibtex, export_to_csljson, export_to_csv, export_to_json, export_to_ris
 from zotero_librarian.import_ import import_by_doi, import_by_isbn, import_by_pmid
-from zotero_librarian.items import add_tags_to_item, delete_item, move_item_to_collection, remove_tags_from_item, update_item_fields
+from zotero_librarian.items import add_tags_to_item, move_item_to_collection, remove_tags_from_item, trash_item, update_item_fields
 from zotero_librarian.query import (
     all_tags,
     find_notes,
@@ -212,11 +212,11 @@ def zotero_export(
 
 
 @mcp.tool()
-def zotero_delete_items(item_keys: Annotated[list[str], Field(description="Item keys to move to trash")]) -> dict:
+def zotero_trash_items(item_keys: Annotated[list[str], Field(description="Item keys to move to trash")]) -> dict:
     """Use when you need to move one or more Zotero items to trash."""
     if len(item_keys) == 1:
-        return delete_item(_zot(), item_keys[0])
-    return batch_delete_items(_zot(), item_keys)
+        return trash_item(_zot(), item_keys[0])
+    return batch_trash_items(_zot(), item_keys)
 
 
 @mcp.tool()
@@ -305,9 +305,9 @@ def zotero_cleanup(
     """
     zot = _zot()
     if action == "snapshots":
-        return delete_snapshots(zot, dry_run=dry_run)
+        return trash_snapshots(zot, dry_run=dry_run)
     if action == "notes":
-        return delete_all_notes(zot, dry_run=dry_run)
+        return trash_all_notes(zot, dry_run=dry_run)
     if action == "missing_pdfs":
         return clean_missing_pdfs(zot, dry_run=dry_run, storage_root=storage_root)
     return {"error": f"Unknown action: {action}"}

--- a/python/pyproject.toml
+++ b/python/pyproject.toml
@@ -7,6 +7,7 @@ dependencies = [
     "pyzotero>=1.10.0",
     "httpx>=0.25.0",
     "rapidfuzz>=3.0.0",
+    "PyYAML>=6.0.2",
 ]
 
 [project.optional-dependencies]

--- a/python/src/zotero_librarian/_cli.py
+++ b/python/src/zotero_librarian/_cli.py
@@ -105,7 +105,7 @@ def cmd_children(args) -> None:
 
 
 def cmd_collections(args) -> None:
-    from .collections import create_collection, delete_collection, move_collection, rename_collection
+    from .collections import create_collection, move_collection, rename_collection, trash_collection
     from .items import add_item_to_collection, move_item_to_collection
     from .query import get_collections
 
@@ -114,8 +114,8 @@ def cmd_collections(args) -> None:
         _print(get_collections(zot))
     elif args.action == "create":
         _print(create_collection(zot, args.name, args.parent))
-    elif args.action == "delete":
-        _print(delete_collection(zot, args.key))
+    elif args.action == "trash":
+        _print(trash_collection(zot, args.key))
     elif args.action == "rename":
         _print(rename_collection(zot, args.key, args.name))
     elif args.action == "move-item":
@@ -216,15 +216,15 @@ def cmd_update(args) -> None:
     _print(update_item_fields(_zot(), args.key, json.loads(args.fields_json)))
 
 
-def cmd_delete(args) -> None:
-    from .batch import batch_delete_items
-    from .items import delete_item
+def cmd_trash(args) -> None:
+    from .batch import batch_trash_items
+    from .items import trash_item
 
     zot = _zot()
     if len(args.keys) == 1:
-        _print(delete_item(zot, args.keys[0]))
+        _print(trash_item(zot, args.keys[0]))
     else:
-        _print(batch_delete_items(zot, args.keys))
+        _print(batch_trash_items(zot, args.keys))
 
 
 def cmd_check_pdfs(_args) -> None:
@@ -271,14 +271,14 @@ def cmd_fetch_pdfs(args) -> None:
 
 
 def cmd_cleanup(args) -> None:
-    from .cleanup import clean_missing_pdfs, delete_all_notes, delete_snapshots
+    from .cleanup import clean_missing_pdfs, trash_all_notes, trash_snapshots
 
     zot = _zot()
     dry_run = not args.apply
     if args.action == "snapshots":
-        _print(delete_snapshots(zot, dry_run=dry_run))
+        _print(trash_snapshots(zot, dry_run=dry_run))
     elif args.action == "notes":
-        _print(delete_all_notes(zot, dry_run=dry_run))
+        _print(trash_all_notes(zot, dry_run=dry_run))
     elif args.action == "missing-pdfs":
         _print(clean_missing_pdfs(zot, dry_run=dry_run, storage_root=args.storage_root))
 
@@ -371,11 +371,11 @@ def build_parser() -> argparse.ArgumentParser:
     update.add_argument("key", help="Item key")
     update.add_argument("fields_json", help='Fields as JSON, e.g. \'{"title": "New Title"}\'')
 
-    delete = sub.add_parser("delete", help="Move one or more items to trash")
-    delete.add_argument("keys", nargs="+", help="Item key(s)")
+    trash = sub.add_parser("trash", help="Move one or more items to trash")
+    trash.add_argument("keys", nargs="+", help="Item key(s)")
 
     collections = sub.add_parser("collections", help="Collection management")
-    collections.add_argument("action", choices=["list", "create", "delete", "rename", "move-item", "add-item", "move"])
+    collections.add_argument("action", choices=["list", "create", "trash", "rename", "move-item", "add-item", "move"])
     collections.add_argument("--key", help="Collection key")
     collections.add_argument("--name", help="Collection name")
     collections.add_argument("--parent", help="Parent collection key")
@@ -471,7 +471,7 @@ def main() -> None:
         "get": cmd_get,
         "children": cmd_children,
         "update": cmd_update,
-        "delete": cmd_delete,
+        "trash": cmd_trash,
         "collections": cmd_collections,
         "tags": cmd_tags,
         "import": cmd_import,

--- a/python/src/zotero_librarian/_dispatch.py
+++ b/python/src/zotero_librarian/_dispatch.py
@@ -4,8 +4,8 @@ import json
 import sys
 
 from .attachments import extract_and_attach_text, rename_pdf_attachments
-from .batch import batch_delete_items
-from .cleanup import clean_missing_pdfs, delete_all_notes, delete_snapshots
+from .batch import batch_trash_items
+from .cleanup import clean_missing_pdfs, trash_all_notes, trash_snapshots
 from .client import count_items, get_zotero
 from .connector import result_from_exception
 from .duplicates import duplicate_dois, duplicate_titles, find_fuzzy_duplicates_by_title
@@ -22,9 +22,9 @@ from .import_ import import_by_doi, import_by_isbn, import_by_pmid
 from .lookup import lookup, lookup_citekey, lookup_zotero_key
 from .items import (
     add_tags_to_item,
-    delete_item,
     move_item_to_collection,
     remove_tags_from_item,
+    trash_item,
     update_item_fields,
 )
 from .query import (
@@ -74,8 +74,8 @@ TOOLS = {
     "add_tags_to_item": lambda zot, a: add_tags_to_item(zot, a["item_key"], a["tags"]),
     "remove_tags_from_item": lambda zot, a: remove_tags_from_item(zot, a["item_key"], a["tags"]),
     "move_item_to_collection": lambda zot, a: move_item_to_collection(zot, a["item_key"], a["collection_key"]),
-    "delete_item": lambda zot, a: delete_item(zot, a["item_key"]),
-    "delete_items": lambda zot, a: batch_delete_items(zot, a["item_keys"]),
+    "trash_item": lambda zot, a: trash_item(zot, a["item_key"]),
+    "trash_items": lambda zot, a: batch_trash_items(zot, a["item_keys"]),
     "library_summary": lambda zot, a: library_summary(zot),
     "items_per_type": lambda zot, a: items_per_type(zot),
     "items_per_year": lambda zot, a: items_per_year(zot),
@@ -95,11 +95,11 @@ TOOLS = {
         apply=a.get("apply", False),
         limit=a.get("limit"),
     ),
-    "delete_snapshots": lambda zot, a: delete_snapshots(
+    "trash_snapshots": lambda zot, a: trash_snapshots(
         zot,
         dry_run=a.get("dry_run", True),
     ),
-    "delete_all_notes": lambda zot, a: delete_all_notes(
+    "trash_all_notes": lambda zot, a: trash_all_notes(
         zot,
         dry_run=a.get("dry_run", True),
     ),

--- a/python/src/zotero_librarian/attachments.py
+++ b/python/src/zotero_librarian/attachments.py
@@ -5,6 +5,7 @@ Attachment file operations for Zotero library items.
 """
 
 import os
+import base64
 import shutil
 import tempfile
 from pathlib import Path
@@ -15,18 +16,19 @@ from pyzotero import zotero
 
 from .connector import (
     ConnectorWriteError,
-    FULLTEXT_ATTACH_PATH,
+    CONNECTOR_TIMEOUT,
     MIN_LOCAL_PLUGIN_VERSION,
-    endpoint_url,
     error_result,
     local_write,
+    plugin_endpoint_path,
+    plugin_endpoint_url,
     require_local_plugin_version,
 )
+from .settings import fulltext_allowed_dirs
 
 
-FULLTEXT_ATTACH_URL = endpoint_url(FULLTEXT_ATTACH_PATH)
-FULLTEXT_ATTACH_TIMEOUT = 30.0
-FULLTEXT_ALLOWED_DIRS = (Path("/tmp"), Path("/var/tmp"))
+FULLTEXT_ALLOWED_DIRS = fulltext_allowed_dirs()
+FULLTEXT_STAGING_DIR = FULLTEXT_ALLOWED_DIRS[0]
 
 
 def _is_fulltext_allowed_path(file_path: Path) -> bool:
@@ -40,12 +42,34 @@ def _stage_file_for_fulltext_attach(file_path: Path) -> tuple[Path, bool]:
     with tempfile.NamedTemporaryFile(
         prefix="zotero-fulltext-",
         suffix=file_path.suffix,
-        dir="/tmp",
+        dir=str(FULLTEXT_STAGING_DIR),
         delete=False,
     ) as staged_handle:
         staged_path = Path(staged_handle.name)
     shutil.copy2(file_path, staged_path)
     return staged_path, True
+
+
+def _plugin_supports_capability(plugin_info: dict[str, Any], capability: str) -> bool:
+    capabilities = plugin_info.get("capabilities")
+    return isinstance(capabilities, list) and capability in capabilities
+
+
+def _attach_bytes_payload(parent_item_key: str, source_file: Path, title: str) -> dict[str, Any]:
+    return {
+        "item_key": parent_item_key,
+        "title": title,
+        "file_name": source_file.name,
+        "file_bytes_base64": base64.b64encode(source_file.read_bytes()).decode("ascii"),
+    }
+
+
+def _is_missing_file_attach_error(response_data: dict[str, Any]) -> bool:
+    error = response_data.get("error")
+    return isinstance(error, str) and (
+        "NS_ERROR_FILE_NOT_FOUND" in error
+        or error.startswith("File not found:")
+    )
 
 
 def attach_file_to_item(
@@ -98,10 +122,12 @@ def attach_file_to_item(
             MIN_LOCAL_PLUGIN_VERSION,
             operation=operation,
         )
+        attach_path = plugin_endpoint_path(plugin_info, "attach")
+        attach_url = plugin_endpoint_url(plugin_info, "attach")
         response = httpx.post(
-            FULLTEXT_ATTACH_URL,
+            attach_url,
             json=payload,
-            timeout=FULLTEXT_ATTACH_TIMEOUT,
+            timeout=CONNECTOR_TIMEOUT,
         )
     except ConnectorWriteError as exc:
         return exc.to_dict()
@@ -109,10 +135,11 @@ def attach_file_to_item(
         return error_result(
             operation,
             "fulltext_attach_request",
-            f"Request to {FULLTEXT_ATTACH_URL} failed",
+            f"Request to {attach_url} failed",
             details={
                 "parent_item_key": parent_item_key,
                 "file_path": file_path,
+                "endpoint": attach_path,
                 "staged_file_path": str(staged_path),
                 "exception_type": type(exc).__name__,
             },
@@ -125,10 +152,11 @@ def attach_file_to_item(
         return error_result(
             operation,
             "fulltext_attach_endpoint",
-            "The /fulltext-attach Zotero plugin endpoint is not available.",
+            "The configured attach endpoint is not available.",
             details={
                 "parent_item_key": parent_item_key,
                 "file_path": file_path,
+                "endpoint": attach_path,
                 "status_code": response.status_code,
                 "body": response.text,
             },
@@ -140,23 +168,67 @@ def attach_file_to_item(
         return error_result(
             operation,
             "parse_response",
-            "The /fulltext-attach endpoint did not return valid JSON.",
+            "The configured attach endpoint did not return valid JSON.",
             details={
                 "parent_item_key": parent_item_key,
                 "file_path": file_path,
+                "endpoint": attach_path,
                 "status_code": response.status_code,
                 "body": response.text,
             },
         )
 
+    if (
+        not response_data.get("success")
+        and _plugin_supports_capability(plugin_info, "attach_bytes")
+        and _is_missing_file_attach_error(response_data)
+    ):
+        try:
+            response = httpx.post(
+                attach_url,
+                json=_attach_bytes_payload(parent_item_key, source_file, title),
+                timeout=CONNECTOR_TIMEOUT,
+            )
+        except httpx.HTTPError as exc:
+            return error_result(
+                operation,
+                "fulltext_attach_request",
+                f"Request to {attach_url} failed",
+                details={
+                    "parent_item_key": parent_item_key,
+                    "file_path": file_path,
+                    "endpoint": attach_path,
+                    "staged_file_path": str(staged_path),
+                    "exception_type": type(exc).__name__,
+                    "retry_mode": "attach_bytes",
+                },
+            )
+        try:
+            response_data = response.json()
+        except ValueError:
+            return error_result(
+                operation,
+                "parse_response",
+                "The configured attach endpoint did not return valid JSON.",
+                details={
+                    "parent_item_key": parent_item_key,
+                    "file_path": file_path,
+                    "endpoint": attach_path,
+                    "status_code": response.status_code,
+                    "body": response.text,
+                    "retry_mode": "attach_bytes",
+                },
+            )
+
     if not response_data.get("success"):
         return error_result(
             operation,
             "fulltext_attach_endpoint",
-            response_data.get("error", "The /fulltext-attach endpoint reported a failure."),
+            response_data.get("error", "The configured attach endpoint reported a failure."),
             details={
                 "parent_item_key": parent_item_key,
                 "file_path": file_path,
+                "endpoint": attach_path,
                 "status_code": response.status_code,
                 "response": response_data,
             },
@@ -179,9 +251,9 @@ def attach_file_to_item(
 def upload_pdf(zot: zotero.Zotero, parent_item_key: str, pdf_path: str, title: str = None) -> dict:
     """Upload a PDF file as an attachment to an item.
 
-    Uses the installed local `/fulltext-attach` plugin endpoint to attach the
-    PDF to an existing item as a stored Zotero attachment. Files outside
-    `/tmp` and `/var/tmp` are staged into `/tmp` before the request.
+    Uses the installed local add-on's configured attach endpoint to attach the
+    PDF to an existing item as a stored Zotero attachment. Files outside the
+    configured staging directories are copied into one of them before upload.
 
     Args:
         zot: Zotero client
@@ -610,7 +682,7 @@ def extract_and_attach_text(
     """Extract text from a PDF attachment and upload the result as a Markdown attachment.
 
     Finds the first PDF attachment child of item_key, runs the configured extractor,
-    and uploads the output as a new child attachment via the /fulltext-attach endpoint.
+    and uploads the output as a new child attachment via the configured attach endpoint.
 
     Args:
         zot:        Zotero client.

--- a/python/src/zotero_librarian/batch.py
+++ b/python/src/zotero_librarian/batch.py
@@ -12,7 +12,7 @@ from .items import (
     add_tags_to_item,
     remove_tags_from_item,
     move_item_to_collection,
-    delete_item,
+    trash_item,
 )
 
 
@@ -119,7 +119,7 @@ def batch_move_to_collection(
     return result
 
 
-def batch_delete_items(
+def batch_trash_items(
     zot: zotero.Zotero,
     item_keys: list[str]
 ) -> dict[str, list[str]]:
@@ -127,7 +127,7 @@ def batch_delete_items(
 
     Args:
         zot: Zotero client
-        item_keys: List of item keys to delete
+        item_keys: List of item keys to trash
 
     Returns:
         Dict with "success" and "failed" lists of item keys
@@ -138,7 +138,7 @@ def batch_delete_items(
     result = {"success": [], "failed": []}
     for item_key in item_keys:
         try:
-            _record_batch_result(result, item_key, delete_item(zot, item_key))
+            _record_batch_result(result, item_key, trash_item(zot, item_key))
         except Exception:
             result["failed"].append(item_key)
     return result

--- a/python/src/zotero_librarian/cleanup.py
+++ b/python/src/zotero_librarian/cleanup.py
@@ -10,10 +10,10 @@ from typing import Any
 from pyzotero import zotero
 
 from .client import _all_items
-from .items import delete_item
+from .items import trash_item
 
 
-def delete_snapshots(
+def trash_snapshots(
     zot: zotero.Zotero,
     *,
     dry_run: bool = True,
@@ -30,9 +30,9 @@ def delete_snapshots(
     Returns:
         Dict with:
             - dry_run: bool
-            - count: number of snapshots found (or deleted when dry_run=False)
+            - count: number of snapshots found (or trashed when dry_run=False)
             - items: list of dicts with 'key', 'title', 'filename', 'contentType'
-            - results: list of delete operation results (empty when dry_run=True)
+            - results: list of trash operation results (empty when dry_run=True)
     """
     snapshots: list[dict[str, Any]] = []
 
@@ -61,7 +61,7 @@ def delete_snapshots(
     results: list[dict[str, Any]] = []
     if not dry_run:
         for snap in snapshots:
-            result = delete_item(zot, snap["key"])
+            result = trash_item(zot, snap["key"])
             results.append({"key": snap["key"], **result})
 
     return {
@@ -72,7 +72,7 @@ def delete_snapshots(
     }
 
 
-def delete_all_notes(
+def trash_all_notes(
     zot: zotero.Zotero,
     *,
     dry_run: bool = True,
@@ -86,9 +86,9 @@ def delete_all_notes(
     Returns:
         Dict with:
             - dry_run: bool
-            - count: number of notes found (or deleted when dry_run=False)
+            - count: number of notes found (or trashed when dry_run=False)
             - items: list of dicts with 'key', 'parent_key', 'snippet'
-            - results: list of delete operation results (empty when dry_run=True)
+            - results: list of trash operation results (empty when dry_run=True)
     """
     import re
 
@@ -110,7 +110,7 @@ def delete_all_notes(
     results: list[dict[str, Any]] = []
     if not dry_run:
         for note_info in notes:
-            result = delete_item(zot, note_info["key"])
+            result = trash_item(zot, note_info["key"])
             results.append({"key": note_info["key"], **result})
 
     return {
@@ -141,9 +141,9 @@ def clean_missing_pdfs(
     Returns:
         Dict with:
             - dry_run: bool
-            - count: number of dangling records found (or deleted when dry_run=False)
+            - count: number of dangling records found (or trashed when dry_run=False)
             - items: list of dicts with 'key', 'filename', 'expected_path'
-            - results: list of delete operation results (empty when dry_run=True)
+            - results: list of trash operation results (empty when dry_run=True)
     """
     if storage_root is None:
         base = Path.home() / "Zotero" / "storage"
@@ -180,7 +180,7 @@ def clean_missing_pdfs(
     results: list[dict[str, Any]] = []
     if not dry_run:
         for record in dangling:
-            result = delete_item(zot, record["key"])
+            result = trash_item(zot, record["key"])
             results.append({"key": record["key"], **result})
 
     return {

--- a/python/src/zotero_librarian/collections.py
+++ b/python/src/zotero_librarian/collections.py
@@ -54,13 +54,13 @@ def create_collection(zot: zotero.Zotero, name: str, parent_key: str = None) -> 
     )
 
 
-def delete_collection(zot: zotero.Zotero, collection_key: str) -> dict[str, Any]:
-    """Delete a collection (moves to trash)."""
+def trash_collection(zot: zotero.Zotero, collection_key: str) -> dict[str, Any]:
+    """Move a collection to trash."""
     try:
         collection = _get_collection(zot, collection_key)
     except Exception as exc:
-        return result_from_exception("delete_collection", exc)
-    return _trash_write_result("delete_collection", **_collection_details(collection))
+        return result_from_exception("trash_collection", exc)
+    return _trash_write_result("trash_collection", **_collection_details(collection))
 
 
 def rename_collection(zot: zotero.Zotero, collection_key: str, new_name: str) -> dict[str, Any]:

--- a/python/src/zotero_librarian/config.yaml
+++ b/python/src/zotero_librarian/config.yaml
@@ -1,0 +1,17 @@
+connector:
+  base_url: http://127.0.0.1:23119
+  timeout_seconds: 30.0
+  poll_attempts: 20
+  poll_delay_seconds: 0.25
+plugin:
+  minimum_version: '3.1'
+  version_probe_path: /version
+  fallback_endpoints:
+    attach: /attach
+    write: /write
+  feature_minimum_versions:
+    delete_tag: 3.2.1
+fulltext_attach:
+  allowed_dirs:
+  - /tmp
+  - /var/tmp

--- a/python/src/zotero_librarian/connector.py
+++ b/python/src/zotero_librarian/connector.py
@@ -8,15 +8,23 @@ from typing import Any
 import httpx
 from pyzotero import zotero
 
+from .settings import (
+    connector_base_url,
+    connector_poll_attempts,
+    connector_poll_delay_seconds,
+    connector_timeout_seconds,
+    plugin_fallback_endpoint_path,
+    plugin_minimum_version,
+    plugin_version_probe_path,
+)
 
-CONNECTOR_BASE_URL = "http://127.0.0.1:23119"
-CONNECTOR_TIMEOUT = 30.0
-CONNECTOR_POLL_ATTEMPTS = 20
-CONNECTOR_POLL_DELAY = 0.25
-FULLTEXT_ATTACH_PATH = "/fulltext-attach"
-LOCAL_WRITE_PATH = "/opencode-zotero-write"
-PLUGIN_VERSION_PATH = "/opencode-zotero-plugin-version"
-MIN_LOCAL_PLUGIN_VERSION = "3.1"
+
+CONNECTOR_BASE_URL = connector_base_url()
+CONNECTOR_TIMEOUT = connector_timeout_seconds()
+CONNECTOR_POLL_ATTEMPTS = connector_poll_attempts()
+CONNECTOR_POLL_DELAY = connector_poll_delay_seconds()
+PLUGIN_VERSION_PATH = plugin_version_probe_path()
+MIN_LOCAL_PLUGIN_VERSION = plugin_minimum_version()
 
 
 class ConnectorWriteError(RuntimeError):
@@ -71,6 +79,19 @@ def result_from_exception(operation: str, exc: Exception) -> dict[str, Any]:
 
 def endpoint_url(path: str) -> str:
     return f"{CONNECTOR_BASE_URL}{path}"
+
+
+def plugin_endpoint_path(plugin_info: dict[str, Any], endpoint_name: str) -> str:
+    endpoints = plugin_info.get("endpoints")
+    if isinstance(endpoints, dict):
+        endpoint_path = endpoints.get(endpoint_name)
+        if isinstance(endpoint_path, str) and endpoint_path.startswith("/"):
+            return endpoint_path
+    return plugin_fallback_endpoint_path(endpoint_name)
+
+
+def plugin_endpoint_url(plugin_info: dict[str, Any], endpoint_name: str) -> str:
+    return endpoint_url(plugin_endpoint_path(plugin_info, endpoint_name))
 
 
 def _parse_release_version(version: str) -> tuple[int, ...]:
@@ -486,8 +507,9 @@ def local_write(
     except ConnectorWriteError as exc:
         return exc.to_dict()
 
+    write_path = plugin_endpoint_path(plugin_info, "write")
     response = _post_json(
-        LOCAL_WRITE_PATH,
+        write_path,
         request_payload,
         operation=result_operation,
         stage="local_write_request",
@@ -496,9 +518,10 @@ def local_write(
         return error_result(
             result_operation,
             "local_write_endpoint",
-            "The /opencode-zotero-write Zotero plugin endpoint is not available.",
+            "The configured local write endpoint is not available.",
             details={
                 "endpoint_operation": endpoint_operation,
+                "endpoint": write_path,
                 "status_code": response.status_code,
                 "body": response.text,
             },

--- a/python/src/zotero_librarian/items.py
+++ b/python/src/zotero_librarian/items.py
@@ -420,12 +420,12 @@ def add_citation_relation(zot: zotero.Zotero, item_key: str, relation_type: str,
     )
 
 
-def delete_item(zot: zotero.Zotero, item_key: str) -> dict:
+def trash_item(zot: zotero.Zotero, item_key: str) -> dict:
     """Move an item to trash.
 
     Args:
         zot: Zotero client
-        item_key: Key of item to delete
+        item_key: Key of item to trash
 
     Returns:
         Response from Zotero API
@@ -436,11 +436,11 @@ def delete_item(zot: zotero.Zotero, item_key: str) -> dict:
     try:
         get_item(zot, item_key)
     except Exception as exc:
-        return result_from_exception("delete_item", exc)
+        return result_from_exception("trash_item", exc)
     return local_write(
         "trash_item",
         payload={"item_key": item_key},
-        operation="delete_item",
+        operation="trash_item",
     )
 
 
@@ -647,7 +647,7 @@ def merge_items(zot: zotero.Zotero, source_key: str, target_key: str) -> dict:
 
     Args:
         zot: Zotero client
-        source_key: Key of the source item (will be merged and deleted)
+        source_key: Key of the source item (will be merged and trashed)
         target_key: Key of the target item (will receive all data)
 
     Returns:

--- a/python/src/zotero_librarian/notes.py
+++ b/python/src/zotero_librarian/notes.py
@@ -53,14 +53,14 @@ def update_note(zot: zotero.Zotero, note_key: str, new_content: str) -> dict[str
     )
 
 
-def delete_note(zot: zotero.Zotero, note_key: str) -> dict[str, Any]:
-    """Delete a note from Zotero."""
+def trash_note(zot: zotero.Zotero, note_key: str) -> dict[str, Any]:
+    """Move a note to trash."""
     try:
-        note = _get_note(zot, note_key, operation="delete_note")
+        note = _get_note(zot, note_key, operation="trash_note")
     except Exception as exc:
-        return result_from_exception("delete_note", exc)
+        return result_from_exception("trash_note", exc)
     return _trash_write_result(
-        "delete_note",
+        "trash_note",
         note_key=note_key,
         parent_item_key=note.get("data", {}).get("parentItem"),
     )

--- a/python/src/zotero_librarian/settings.py
+++ b/python/src/zotero_librarian/settings.py
@@ -1,0 +1,140 @@
+from __future__ import annotations
+
+import os
+from functools import lru_cache
+from importlib.resources import files
+from pathlib import Path
+from typing import Any
+
+import yaml
+
+
+_CONFIG_ENV_VAR = "ZOTERO_LIBRARIAN_CONFIG"
+_CONFIG_RESOURCE = "config.yaml"
+
+
+def _config_source() -> tuple[str, str]:
+    override_path = os.environ.get(_CONFIG_ENV_VAR)
+    if override_path:
+        return "path", str(Path(override_path).expanduser())
+    return "resource", _CONFIG_RESOURCE
+
+
+def _read_config_text() -> tuple[str, str]:
+    source_kind, source_value = _config_source()
+    if source_kind == "path":
+        config_path = Path(source_value)
+        return str(config_path), config_path.read_text(encoding="utf-8")
+    resource = files("zotero_librarian").joinpath(source_value)
+    return f"package:{source_value}", resource.read_text(encoding="utf-8")
+
+
+def _require_mapping(value: Any, *, path: str, source: str) -> dict[str, Any]:
+    if not isinstance(value, dict):
+        raise RuntimeError(f"Expected mapping at {path!r} in {source}")
+    return value
+
+
+def _require_string(value: Any, *, path: str, source: str) -> str:
+    if not isinstance(value, str) or not value:
+        raise RuntimeError(f"Expected non-empty string at {path!r} in {source}")
+    return value
+
+
+def _require_float(value: Any, *, path: str, source: str) -> float:
+    if not isinstance(value, (int, float)):
+        raise RuntimeError(f"Expected number at {path!r} in {source}")
+    return float(value)
+
+
+def _require_int(value: Any, *, path: str, source: str) -> int:
+    if not isinstance(value, int):
+        raise RuntimeError(f"Expected integer at {path!r} in {source}")
+    return value
+
+
+@lru_cache(maxsize=1)
+def _settings() -> tuple[str, dict[str, Any]]:
+    source, raw_text = _read_config_text()
+    parsed = yaml.safe_load(raw_text)
+    settings = _require_mapping(parsed, path="$", source=source)
+    return source, settings
+
+
+def _section(name: str) -> tuple[str, dict[str, Any]]:
+    source, settings = _settings()
+    return source, _require_mapping(settings.get(name), path=name, source=source)
+
+
+def connector_base_url() -> str:
+    source, section = _section("connector")
+    return _require_string(section.get("base_url"), path="connector.base_url", source=source)
+
+
+def connector_timeout_seconds() -> float:
+    source, section = _section("connector")
+    return _require_float(section.get("timeout_seconds"), path="connector.timeout_seconds", source=source)
+
+
+def connector_poll_attempts() -> int:
+    source, section = _section("connector")
+    return _require_int(section.get("poll_attempts"), path="connector.poll_attempts", source=source)
+
+
+def connector_poll_delay_seconds() -> float:
+    source, section = _section("connector")
+    return _require_float(section.get("poll_delay_seconds"), path="connector.poll_delay_seconds", source=source)
+
+
+def plugin_minimum_version() -> str:
+    source, section = _section("plugin")
+    return _require_string(section.get("minimum_version"), path="plugin.minimum_version", source=source)
+
+
+def plugin_feature_minimum_version(feature_name: str) -> str:
+    source, section = _section("plugin")
+    feature_versions = _require_mapping(
+        section.get("feature_minimum_versions"),
+        path="plugin.feature_minimum_versions",
+        source=source,
+    )
+    return _require_string(
+        feature_versions.get(feature_name),
+        path=f"plugin.feature_minimum_versions.{feature_name}",
+        source=source,
+    )
+
+
+def plugin_version_probe_path() -> str:
+    source, section = _section("plugin")
+    return _require_string(section.get("version_probe_path"), path="plugin.version_probe_path", source=source)
+
+
+def plugin_fallback_endpoint_path(endpoint_name: str) -> str:
+    source, section = _section("plugin")
+    fallback_endpoints = _require_mapping(
+        section.get("fallback_endpoints"),
+        path="plugin.fallback_endpoints",
+        source=source,
+    )
+    return _require_string(
+        fallback_endpoints.get(endpoint_name),
+        path=f"plugin.fallback_endpoints.{endpoint_name}",
+        source=source,
+    )
+
+
+def fulltext_allowed_dirs() -> tuple[Path, ...]:
+    source, section = _section("fulltext_attach")
+    raw_dirs = section.get("allowed_dirs")
+    if not isinstance(raw_dirs, list) or not raw_dirs:
+        raise RuntimeError(f"Expected non-empty list at 'fulltext_attach.allowed_dirs' in {source}")
+    paths: list[Path] = []
+    for index, raw_dir in enumerate(raw_dirs):
+        raw_path = _require_string(
+            raw_dir,
+            path=f"fulltext_attach.allowed_dirs[{index}]",
+            source=source,
+        )
+        paths.append(Path(raw_path))
+    return tuple(paths)

--- a/python/src/zotero_librarian/tags.py
+++ b/python/src/zotero_librarian/tags.py
@@ -7,7 +7,17 @@ from typing import Any
 from pyzotero import zotero
 
 from .client import _all_items
-from .connector import error_result, local_write, result_from_exception
+from .connector import (
+    ConnectorWriteError,
+    error_result,
+    local_write,
+    require_local_plugin_version,
+    result_from_exception,
+)
+from .settings import plugin_feature_minimum_version
+
+
+DELETE_TAG_MIN_PLUGIN_VERSION = plugin_feature_minimum_version("delete_tag")
 
 
 def _noop_result(operation: str, **details: Any) -> dict[str, Any]:
@@ -169,6 +179,14 @@ def delete_tag(zot: zotero.Zotero, tag_name: str) -> dict[str, Any]:
             updated_items=0,
             tag_name=cleaned_tag_name,
         )
+    try:
+        require_local_plugin_version(
+            DELETE_TAG_MIN_PLUGIN_VERSION,
+            operation="delete_tag",
+        )
+    except ConnectorWriteError as exc:
+        return exc.to_dict()
+
     return _merge_details(
         local_write(
             "delete_tag",

--- a/python/tests/test_adversarial.py
+++ b/python/tests/test_adversarial.py
@@ -4,7 +4,14 @@ Adversarial Integration Tests for Zotero Librarian Toolkit
 These tests use the REAL Zotero local API (no mocks) to verify robustness
 against edge cases, invalid inputs, and adversarial scenarios.
 
-All tests use a single test item created at session start and deleted at end.
+Threat model:
+    - The adversary is the caller or agent using the tool surface.
+    - This suite should test tool-contract misuse, bad sequencing, and
+      structured failure behavior against a real Zotero.
+    - This suite should not try to re-prove Zotero's own schema or field
+      validation with pathological metadata values.
+
+All tests use a single test item created at session start and trashed at end.
 Tests are idempotent and clean up after themselves.
 
 Requirements:
@@ -14,6 +21,7 @@ Requirements:
 """
 
 import pytest
+from copy import deepcopy
 import time
 from typing import Any
 from uuid import uuid4
@@ -25,10 +33,10 @@ from zotero_librarian.query import get_item, get_notes, get_attachments, get_cit
 from zotero_librarian.items import (
     update_item_fields, add_tags_to_item, remove_tags_from_item,
     move_item_to_collection, add_item_to_collection, remove_item_from_collection,
-    attach_note, add_citation_relation, delete_item,
+    attach_note, add_citation_relation, trash_item,
 )
-from zotero_librarian.notes import update_note, delete_note
-from zotero_librarian.collections import create_collection, delete_collection, rename_collection
+from zotero_librarian.notes import trash_note, update_note
+from zotero_librarian.collections import create_collection, rename_collection, trash_collection
 from zotero_librarian.tags import merge_tags, rename_tag, delete_tag
 from zotero_librarian.validation import validate_doi, validate_isbn, validate_issn
 
@@ -36,6 +44,38 @@ from zotero_librarian.validation import validate_doi, validate_isbn, validate_is
 # =============================================================================
 # Test Fixtures
 # =============================================================================
+
+TEST_ITEM_BASE_FIELDS = {
+    "itemType": "book",
+    "title": "Test Item - DO NOT EDIT MANUALLY",
+    "creators": [
+        {"creatorType": "author", "firstName": "Test", "lastName": "User"}
+    ],
+    "date": "2024",
+    "publisher": "Test Publisher",
+    "place": "Test City",
+    "ISBN": "978-0-00-000000-0",
+    "abstractNote": "Test abstract for adversarial testing",
+    "url": "https://example.com/test",
+    "accessDate": "2024-01-01",
+    "pages": "1-100",
+    "numberOfPages": "100",
+    "language": "en",
+    "libraryCatalog": "Test Catalog",
+    "callNumber": "TEST123",
+    "rights": "CC0",
+    "extra": "Test extra field",
+    "series": "Test Series",
+    "seriesNumber": "1",
+    "volume": "1",
+    "edition": "1st",
+    "shortTitle": "Test",
+}
+
+TEST_ITEM_BASE_TAGS: list[str] = []
+TEST_ITEM_BASE_COLLECTIONS: list[str] = []
+TEST_ITEM_BASE_RELATIONS: dict[str, str | list[str]] = {}
+
 
 def check_zotero_available():
     """Check if Zotero local API is available."""
@@ -64,25 +104,25 @@ def _note_key(result: dict[str, Any]) -> str:
     return key
 
 
-def _restore_item_state(zot, item_key: str, original_data: dict[str, Any]) -> None:
-    tag_names = [
-        tag.get("tag", "").strip()
-        for tag in original_data["tags"]
-        if tag.get("tag", "").strip()
-    ]
+def _restore_item_state(zot, item_key: str) -> None:
+    local_write(
+        "update_item_fields",
+        payload={"item_key": item_key, "fields": deepcopy(TEST_ITEM_BASE_FIELDS)},
+        operation="test_restore_item_state_fields",
+    )
     local_write(
         "set_item_tags",
-        payload={"item_key": item_key, "tags": tag_names},
+        payload={"item_key": item_key, "tags": TEST_ITEM_BASE_TAGS},
         operation="test_restore_item_state_tags",
     )
     local_write(
         "set_item_collections",
-        payload={"item_key": item_key, "collection_keys": list(original_data["collections"])},
+        payload={"item_key": item_key, "collection_keys": TEST_ITEM_BASE_COLLECTIONS},
         operation="test_restore_item_state_collections",
     )
     local_write(
         "update_item_fields",
-        payload={"item_key": item_key, "fields": {"relations": original_data["relations"]}},
+        payload={"item_key": item_key, "fields": {"relations": TEST_ITEM_BASE_RELATIONS}},
         operation="test_restore_item_state_relations",
     )
 
@@ -101,35 +141,10 @@ def zot():
 def test_item(zot):
     """
     Create a test item at session start that serves as sandbox for all tests.
-    This item is deleted at session end.
+    This item is trashed at session end.
     """
     # Create a simple book item as our test sandbox
-    item_data = {
-        "itemType": "book",
-        "title": "Test Item - DO NOT EDIT MANUALLY",
-        "creators": [
-            {"creatorType": "author", "firstName": "Test", "lastName": "User"}
-        ],
-        "date": "2024",
-        "publisher": "Test Publisher",
-        "place": "Test City",
-        "ISBN": "978-0-00-000000-0",
-        "abstractNote": "Test abstract for adversarial testing",
-        "url": "https://example.com/test",
-        "accessDate": "2024-01-01",
-        "pages": "1-100",
-        "numberOfPages": "100",
-        "language": "en",
-        "libraryCatalog": "Test Catalog",
-        "callNumber": "TEST123",
-        "rights": "CC0",
-        "extra": "Test extra field",
-        "series": "Test Series",
-        "seriesNumber": "1",
-        "volume": "1",
-        "edition": "1st",
-        "shortTitle": "Test",
-    }
+    item_data = deepcopy(TEST_ITEM_BASE_FIELDS)
 
     # Create the item
     result = save_item(
@@ -146,7 +161,7 @@ def test_item(zot):
     yield item_key
 
     try:
-        delete_item(zot, item_key)
+        trash_item(zot, item_key)
     except Exception:
         pass
 
@@ -155,23 +170,15 @@ def test_item(zot):
 def restore_item_state(zot, test_item):
     """
     Fixture to restore test item state after each test.
-    Captures original state before test and restores it after.
+    Restores the shared sandbox item to its baseline state after each test.
     """
-    # Capture original state
-    original = get_item(zot, test_item)
-    original_data = {
-        "tags": original["data"].get("tags", []),
-        "collections": original["data"].get("collections", []),
-        "relations": original["data"].get("relations", {}),
-    }
-
     yield
 
-    # Restore original state
+    # Restore the baseline sandbox state
     try:
-        _restore_item_state(zot, test_item, original_data)
+        _restore_item_state(zot, test_item)
     except Exception:
-        pass  # Item may have been deleted
+        pass  # Item may already be trashed
 
 
 @pytest.fixture
@@ -182,7 +189,7 @@ def temp_collection(zot):
         collection_key = _collection_key(result)
         yield collection_key
         try:
-            delete_collection(zot, collection_key)
+            trash_collection(zot, collection_key)
         except Exception:
             pass
     else:
@@ -200,25 +207,25 @@ class TestEdgeCasesEmptyStrings:
         """Empty string in title field should be accepted by Zotero."""
         result = update_item_fields(zot, test_item, {"title": ""})
         assert result["success"], "Empty title update should succeed"
-        # Verify item still exists with empty title
+        # Zotero clears the field and may omit the key entirely on read-back.
         item = get_item(zot, test_item)
-        assert item["data"]["title"] == "", f"Expected empty title, got: {item['data']['title']!r}"
+        assert item["data"].get("title", "") == "", f"Expected cleared title, got: {item['data'].get('title', '<missing>')!r}"
 
     def test_update_with_empty_abstract(self, zot, test_item, restore_item_state):
         """Empty string in abstract field should be accepted by Zotero."""
         result = update_item_fields(zot, test_item, {"abstractNote": ""})
         assert result["success"], "Empty abstract update should succeed"
-        # Read back and verify empty abstract was stored
+        # Zotero clears the field and may omit the key entirely on read-back.
         item = get_item(zot, test_item)
-        assert item["data"]["abstractNote"] == "", f"Expected empty abstract, got: {item['data']['abstractNote']!r}"
+        assert item["data"].get("abstractNote", "") == "", f"Expected cleared abstract, got: {item['data'].get('abstractNote', '<missing>')!r}"
 
     def test_update_with_empty_publisher(self, zot, test_item, restore_item_state):
         """Empty string in publisher field should be accepted by Zotero."""
         result = update_item_fields(zot, test_item, {"publisher": ""})
         assert result["success"], "Empty publisher update should succeed"
-        # Read back and verify empty publisher was stored
+        # Zotero clears the field and may omit the key entirely on read-back.
         item = get_item(zot, test_item)
-        assert item["data"]["publisher"] == "", f"Expected empty publisher, got: {item['data']['publisher']!r}"
+        assert item["data"].get("publisher", "") == "", f"Expected cleared publisher, got: {item['data'].get('publisher', '<missing>')!r}"
 
     def test_add_empty_tag(self, zot, test_item, restore_item_state):
         """Adding empty string as tag should be ignored."""
@@ -258,8 +265,9 @@ class TestEdgeCasesNoneValues:
         
         # Read back to see how Zotero handles None
         item = get_item(zot, test_item)
-        # Zotero may keep original or set to empty - both are acceptable
-        assert item["data"]["title"] in (original_title, ""), f"Title should be unchanged or empty, got: {item['data']['title']!r}"
+        # Zotero may keep the original value or clear the field entirely.
+        observed_title = item["data"].get("title", "")
+        assert observed_title in (original_title, ""), f"Title should be unchanged or cleared, got: {observed_title!r}"
 
     def test_update_with_none_date(self, zot, test_item, restore_item_state):
         """None value in date field should be handled gracefully."""
@@ -267,8 +275,9 @@ class TestEdgeCasesNoneValues:
         assert result["success"], "None date update should not crash"
         # Read back and verify date was cleared or kept
         item = get_item(zot, test_item)
-        # Zotero may clear the date or keep original - both acceptable
-        assert item["data"]["date"] in ("2024", ""), f"Date should be original or empty, got: {item['data']['date']!r}"
+        # Zotero may keep the original value or clear the field entirely.
+        observed_date = item["data"].get("date", "")
+        assert observed_date in ("2024", ""), f"Date should be original or cleared, got: {observed_date!r}"
 
     def test_update_with_none_fields_dict(self, zot, test_item, restore_item_state):
         """Multiple None values in fields dict should be handled gracefully."""
@@ -280,14 +289,20 @@ class TestEdgeCasesNoneValues:
         assert result["success"], "Multiple None fields update should not crash"
         # Read back and verify fields were handled
         item = get_item(zot, test_item)
-        # All fields should be either original values or empty
-        assert item["data"]["title"] in ("Test Item - DO NOT EDIT MANUALLY", ""), "Title handling incorrect"
-        assert item["data"]["publisher"] in ("Test Publisher", ""), "Publisher handling incorrect"
+        # All fields should be either original values or cleared from the payload.
+        assert item["data"].get("title", "") in ("Test Item - DO NOT EDIT MANUALLY", ""), "Title handling incorrect"
+        assert item["data"].get("publisher", "") in ("Test Publisher", ""), "Publisher handling incorrect"
 
     def test_add_none_tag(self, zot, test_item, restore_item_state):
-        """None in tags list should raise TypeError or be rejected."""
-        with pytest.raises((TypeError, ValueError)):
-            add_tags_to_item(zot, test_item, [None])
+        """None in tags list should be rejected without mutating the item."""
+        result = add_tags_to_item(zot, test_item, [None])
+
+        assert not result["success"], result
+        assert result["stage"] == "input_validation", result
+        assert result["details"]["tags"] == [None], result
+
+        item = get_item(zot, test_item)
+        assert item["data"].get("tags", []) == [], item["data"].get("tags", [])
 
 
 class TestEdgeCasesUnicode:
@@ -399,12 +414,12 @@ class TestEdgeCasesSpecialCharacters:
         assert item["data"]["title"] == expected, f"Backslashes not preserved: expected {expected!r}, got {item['data']['title']!r}"
 
     def test_title_with_newlines(self, zot, test_item, restore_item_state):
-        """Title with newlines should be stored correctly."""
-        expected = "Line1\nLine2\nLine3"
-        result = update_item_fields(zot, test_item, {"title": expected})
+        """Title newlines should be normalized to spaces by Zotero."""
+        submitted = "Line1\nLine2\nLine3"
+        result = update_item_fields(zot, test_item, {"title": submitted})
         assert result["success"], "Title with newlines update should succeed"
         item = get_item(zot, test_item)
-        assert item["data"]["title"] == expected, f"Newlines not preserved: expected {expected!r}, got {item['data']['title']!r}"
+        assert item["data"]["title"] == "Line1 Line2 Line3", item["data"]["title"]
 
     def test_title_with_tabs(self, zot, test_item, restore_item_state):
         """Title with tabs should be stored correctly."""
@@ -533,7 +548,7 @@ class TestInvalidInputsNonExistentKeys:
 
     def test_delete_nonexistent_item(self, zot):
         """Delete non-existent item."""
-        result = delete_item(zot, "NONEXISTENT123")
+        result = trash_item(zot, "NONEXISTENT123")
         assert not result["success"], "Delete nonexistent item should fail"
 
     def test_add_tag_to_nonexistent_item(self, zot):
@@ -686,8 +701,8 @@ class TestStateCorruption:
             assert len(item["data"].get("collections", [])) >= 2
 
             # Cleanup
-            delete_collection(zot, coll1_key)
-            delete_collection(zot, coll2_key)
+            trash_collection(zot, coll1_key)
+            trash_collection(zot, coll2_key)
 
     def test_circular_collection_reference_attempt(self, zot, test_item):
         """Try to create circular collection reference (should fail gracefully)."""
@@ -711,19 +726,19 @@ class TestStateCorruption:
 
         # Cleanup
         try:
-            delete_collection(zot, coll1_key)
+            trash_collection(zot, coll1_key)
             if coll2_result and coll2_result["success"]:
-                delete_collection(zot, _collection_key(coll2_result))
+                trash_collection(zot, _collection_key(coll2_result))
             if coll3_result and coll3_result.get("success"):
-                delete_collection(zot, _collection_key(coll3_result))
+                trash_collection(zot, _collection_key(coll3_result))
         except Exception:
             pass
 
-    def test_delete_item_then_operate(self, zot):
-        """Try to operate on deleted item."""
+    def test_trash_item_then_operate(self, zot):
+        """Try to operate on a trashed item."""
         item_data = {
             "itemType": "book",
-            "title": _probe_value("deleted-item"),
+            "title": _probe_value("trashed-item"),
             "creators": [{"creatorType": "author", "firstName": "Deleted", "lastName": "Probe"}],
             "date": "2026",
             "publisher": "OpenCode Test Harness",
@@ -732,12 +747,12 @@ class TestStateCorruption:
             zot,
             item_data,
             uri=f"https://example.invalid/{uuid4().hex}",
-            operation="test_delete_item_then_operate",
+            operation="test_trash_item_then_operate",
         )
         assert result["success"], result
         item_key = result["item_key"]
-        delete_result = delete_item(zot, item_key)
-        assert delete_result["success"], delete_result
+        trash_result = trash_item(zot, item_key)
+        assert trash_result["success"], trash_result
         follow_up = update_item_fields(zot, item_key, {"title": "should not persist"})
         assert not follow_up["success"], "Updating a trashed item should fail"
 
@@ -802,26 +817,26 @@ class TestConcurrentModification:
 # =============================================================================
 
 class TestMissingDependencies:
-    """Test operations on deleted items and orphaned references."""
+    """Test operations on trashed items and orphaned references."""
 
-    def test_note_on_deleted_item(self, zot):
-        """Create note, delete parent, try to access note."""
+    def test_note_on_trashed_item(self, zot):
+        """Create note, trash parent, try to access note."""
         item_result = save_item(
             zot,
             {
                 "itemType": "book",
-                "title": _probe_value("note-deleted-parent"),
+                "title": _probe_value("note-trashed-parent"),
                 "creators": [{"creatorType": "author", "firstName": "Note", "lastName": "Probe"}],
                 "date": "2026",
                 "publisher": "OpenCode Test Harness",
             },
             uri=f"https://example.invalid/{uuid4().hex}",
-            operation="test_note_on_deleted_item",
+            operation="test_note_on_trashed_item",
         )
         assert item_result["success"], item_result
         item_key = item_result["item_key"]
-        delete_result = delete_item(zot, item_key)
-        assert delete_result["success"], delete_result
+        trash_result = trash_item(zot, item_key)
+        assert trash_result["success"], trash_result
         note_result = attach_note(zot, item_key, "should not attach")
         assert not note_result["success"], "Attaching a note to a trashed parent should fail"
 
@@ -1011,10 +1026,10 @@ class TestUnicodeHell:
             # Verify note content
             note = zot.note(note_key)
             assert content in note["data"]["note"], f"Unicode note content mismatch"
-            delete_note(zot, note_key)
+            trash_note(zot, note_key)
         except Exception:
             try:
-                delete_note(zot, note_key)
+                trash_note(zot, note_key)
             except Exception:
                 pass
             raise
@@ -1201,10 +1216,10 @@ class TestNoteOperations:
             # Verify note was created with empty content
             note = zot.note(note_key)
             assert note["data"]["note"] == "", f"Empty note content mismatch: {note['data']['note']!r}"
-            delete_note(zot, note_key)
+            trash_note(zot, note_key)
         except Exception:
             try:
-                delete_note(zot, note_key)
+                trash_note(zot, note_key)
             except Exception:
                 pass
             raise
@@ -1219,10 +1234,10 @@ class TestNoteOperations:
             # Verify note was created with HTML content
             note = zot.note(note_key)
             assert html in note["data"]["note"], f"HTML note content mismatch: {note['data']['note']!r}"
-            delete_note(zot, note_key)
+            trash_note(zot, note_key)
         except Exception:
             try:
-                delete_note(zot, note_key)
+                trash_note(zot, note_key)
             except Exception:
                 pass
             raise
@@ -1241,17 +1256,17 @@ class TestNoteOperations:
             # Verify unicode content
             note = zot.note(note_key)
             assert unicode_content in note["data"]["note"], f"Unicode note content mismatch: {note['data']['note']!r}"
-            delete_note(zot, note_key)
+            trash_note(zot, note_key)
         except Exception:
             try:
-                delete_note(zot, note_key)
+                trash_note(zot, note_key)
             except Exception:
                 pass
             raise
 
     def test_delete_nonexistent_note(self, zot):
         """Delete non-existent note should return error dict."""
-        result = delete_note(zot, "NONEXISTENT123")
+        result = trash_note(zot, "NONEXISTENT123")
         # Should return error dict with success=False
         assert not result.get("success", True), "Delete nonexistent note should fail"
 
@@ -1276,7 +1291,7 @@ class TestCollectionOperations:
             # If it succeeded, verify collection was created
             collection_key = _collection_key(result)
             try:
-                delete_collection(zot, collection_key)
+                trash_collection(zot, collection_key)
             except Exception:
                 pass
         else:
@@ -1291,7 +1306,7 @@ class TestCollectionOperations:
             # If it succeeded, verify name was stored
             collection_key = _collection_key(result)
             try:
-                delete_collection(zot, collection_key)
+                trash_collection(zot, collection_key)
             except Exception:
                 pass
         else:
@@ -1310,10 +1325,10 @@ class TestCollectionOperations:
             created = [c for c in collections if c["key"] == collection_key]
             assert len(created) == 1, "Collection should exist"
             assert created[0]["data"]["name"] == unicode_name, f"Unicode name mismatch: {created[0]['data']['name']!r}"
-            delete_collection(zot, collection_key)
+            trash_collection(zot, collection_key)
         except Exception:
             try:
-                delete_collection(zot, collection_key)
+                trash_collection(zot, collection_key)
             except Exception:
                 pass
             raise
@@ -1331,7 +1346,7 @@ class TestCollectionOperations:
 
     def test_delete_nonexistent_collection(self, zot):
         """Delete non-existent collection should return error dict."""
-        result = delete_collection(zot, "NONEXISTENT123")
+        result = trash_collection(zot, "NONEXISTENT123")
         assert not result["success"], "Delete nonexistent collection should fail"
 
     def test_rename_nonexistent_collection(self, zot):
@@ -1454,13 +1469,13 @@ class TestMiscellaneousAdversarial:
     """Additional adversarial test scenarios."""
 
     def test_rapid_collection_operations(self, zot, test_item, restore_item_state):
-        """Rapid create/move/delete collections should all succeed."""
+        """Rapid create/move/trash collections should all succeed."""
         for i in range(5):
             coll_result = create_collection(zot, f"Rapid_{i}_{time.time()}")
             assert coll_result["success"], f"Rapid collection {i} create should succeed"
             coll_key = _collection_key(coll_result)
             move_item_to_collection(zot, test_item, coll_key)
-            delete_collection(zot, coll_key)
+            trash_collection(zot, coll_key)
         # Verify item is back to original state (no collections from rapid ops)
         item = get_item(zot, test_item)
         # Collections may have other collections, but rapid ones should be gone
@@ -1519,7 +1534,7 @@ class TestMiscellaneousAdversarial:
         finally:
             for key in collection_keys:
                 try:
-                    delete_collection(zot, key)
+                    trash_collection(zot, key)
                 except Exception:
                     pass
 

--- a/python/tests/test_enrichment_local_api.py
+++ b/python/tests/test_enrichment_local_api.py
@@ -36,6 +36,14 @@ def _has_pdf(children: list[dict]) -> bool:
     )
 
 
+def _ris_exportable_items(items: list[dict]) -> list[dict]:
+    return [
+        item
+        for item in items
+        if item["data"].get("itemType") not in {"attachment", "note"}
+    ]
+
+
 class TestEnrichmentLocalApi:
     def test_get_children_matches_local_api(self, zot, first_item):
         assert [child["key"] for child in get_children(zot, first_item["key"])] == [
@@ -76,6 +84,7 @@ class TestEnrichmentLocalApi:
     def test_export_to_ris_contains_known_item_title(self, zot, sample_collection, sample_collection_items):
         item = _first_titled_item(sample_collection_items)
         exported = export_to_ris(zot, collection_key=sample_collection["key"])
+        exportable_items = _ris_exportable_items(sample_collection_items)
 
         assert item["data"]["title"] in exported
-        assert exported.count("TY  -") == len(sample_collection_items)
+        assert exported.count("TY  -") == len(exportable_items)

--- a/python/tests/test_write_contract_local_api.py
+++ b/python/tests/test_write_contract_local_api.py
@@ -1,17 +1,18 @@
 from __future__ import annotations
 
 from pathlib import Path
+import time
 from uuid import uuid4
 
 import pytest
 
 from zotero_librarian.attachments import upload_pdf
-from zotero_librarian.batch import batch_delete_items, batch_update_items
+from zotero_librarian.batch import batch_trash_items, batch_update_items
 from zotero_librarian.collections import (
     create_collection as create_collection_entry,
-    delete_collection as delete_collection_entry,
     move_collection,
     rename_collection,
+    trash_collection as trash_collection_entry,
 )
 from zotero_librarian.connector import resolve_target_id, save_item
 from zotero_librarian.enrichment import batch_add_identifiers
@@ -21,14 +22,14 @@ from zotero_librarian.items import (
     add_tags_to_item,
     attach_note,
     attach_url,
-    delete_item,
     move_item_to_collection,
     remove_item_from_collection,
     remove_tags_from_item,
+    trash_item,
     update_item_fields,
 )
-from zotero_librarian.notes import delete_note, update_note
-from zotero_librarian.query import get_attachments, get_item, get_notes, get_trash_items
+from zotero_librarian.notes import trash_note, update_note
+from zotero_librarian.query import get_attachments, get_item, get_notes
 from zotero_librarian.tags import delete_tag, merge_tags, rename_tag
 
 
@@ -62,8 +63,14 @@ def _tag_names(item: dict) -> list[str]:
     ]
 
 
-def _trash_keys(zot) -> set[str]:
-    return {item["key"] for item in get_trash_items(zot)}
+def _is_trashed(zot, item_key: str) -> bool:
+    deadline = time.monotonic() + 5.0
+    while True:
+        if bool(zot.item(item_key).get("data", {}).get("deleted", False)):
+            return True
+        if time.monotonic() >= deadline:
+            return False
+        time.sleep(0.25)
 
 
 def _collection_key(result: dict) -> str:
@@ -109,12 +116,12 @@ class WriteSandbox:
     def cleanup(self) -> None:
         for item_key in reversed(self.item_keys):
             try:
-                delete_item(self.zot, item_key)
+                trash_item(self.zot, item_key)
             except Exception:
                 pass
         for collection_key in reversed(self.collection_keys):
             try:
-                delete_collection_entry(self.zot, collection_key)
+                trash_collection_entry(self.zot, collection_key)
             except Exception:
                 pass
 
@@ -265,23 +272,23 @@ def test_attach_and_update_note_round_trip(zot, sandbox):
     assert any(note["key"] == note_key and updated_content in note["data"].get("note", "") for note in updated_notes)
 
 
-def test_delete_note_moves_note_to_trash(zot, sandbox):
+def test_trash_note_marks_note_as_deleted(zot, sandbox):
     item_key = sandbox.create_item()
     note_key = attach_note(zot, item_key, "<p>trash me</p>")["note_key"]
 
-    result = delete_note(zot, note_key)
+    result = trash_note(zot, note_key)
 
     assert result["success"] is True
-    assert note_key in _trash_keys(zot)
+    assert _is_trashed(zot, note_key)
 
 
-def test_delete_item_moves_item_to_trash(zot, sandbox):
+def test_trash_item_marks_item_as_deleted(zot, sandbox):
     item_key = sandbox.create_item()
 
-    result = delete_item(zot, item_key)
+    result = trash_item(zot, item_key)
 
     assert result["success"] is True
-    assert item_key in _trash_keys(zot)
+    assert _is_trashed(zot, item_key)
 
 
 def test_batch_update_items_persists_changes_to_all_targets(zot, sandbox):
@@ -296,15 +303,14 @@ def test_batch_update_items_persists_changes_to_all_targets(zot, sandbox):
         assert get_item(zot, item_key)["data"]["shortTitle"] == short_title
 
 
-def test_batch_delete_items_moves_all_targets_to_trash(zot, sandbox):
-    item_keys = [sandbox.create_item(title_prefix="batch-delete-a"), sandbox.create_item(title_prefix="batch-delete-b")]
+def test_batch_trash_items_marks_all_targets_as_deleted(zot, sandbox):
+    item_keys = [sandbox.create_item(title_prefix="batch-trash-a"), sandbox.create_item(title_prefix="batch-trash-b")]
 
-    result = batch_delete_items(zot, item_keys)
+    result = batch_trash_items(zot, item_keys)
 
     assert sorted(result["success"]) == sorted(item_keys)
     assert result["failed"] == []
-    trash_keys = _trash_keys(zot)
-    assert set(item_keys) <= trash_keys
+    assert all(_is_trashed(zot, item_key) for item_key in item_keys)
 
 
 def test_rename_tag_updates_existing_items(zot, sandbox):

--- a/src/index.ts
+++ b/src/index.ts
@@ -176,14 +176,14 @@ export const ZoteroPlugin: Plugin = async () => ({
         return JSON.stringify({ error: `Unknown action: ${args.action}` });
       },
     }),
-    zotero_delete_items: tool({
+    zotero_trash_items: tool({
       description: "Use when you need to move one or more Zotero items to trash.",
       args: {
         item_keys: tool.schema.array(tool.schema.string()).describe("Item keys to move to trash"),
       },
       async execute(args) {
-        if (args.item_keys.length === 1) return callZotero("delete_item", { item_key: args.item_keys[0] });
-        return callZotero("delete_items", { item_keys: args.item_keys });
+        if (args.item_keys.length === 1) return callZotero("trash_item", { item_key: args.item_keys[0] });
+        return callZotero("trash_items", { item_keys: args.item_keys });
       },
     }),
     zotero_check_pdfs: tool({


### PR DESCRIPTION
## Why
GitHub `main` was still pinned to obsolete local add-on endpoints and old delete terminology, so a default GitHub-backed OpenCode install exposed the wrong tool surface and failed live local writes against the current Zotero add-on.

## What changed
- centralize connector/add-on endpoint configuration in YAML-backed settings
- switch connector and attachment writes to the current add-on version probe and discovered endpoints
- rename repo-owned removal surfaces to `trash` across the plugin, dispatcher, CLI, MCP, and live write-contract tests
- update requirements/continuation docs to document trash-only semantics, owned add-on responsibility, and caller-adversarial testing

## Proof
- `bun install`
- `bun run typecheck`
- `cd mcp-server && uv run python -c 'import server; print("ok")'`
- `cd python && uv run pytest tests/test_write_contract_local_api.py tests/test_enrichment_local_api.py -v --no-header`